### PR TITLE
Update KeyVault to 1.5.9

### DIFF
--- a/com.polydez.KeyVault.yml
+++ b/com.polydez.KeyVault.yml
@@ -32,5 +32,5 @@ modules:
     sources:
       - type: file
         dest-filename: keyvault-linux.zip
-        url: https://polydez.com/download/keyvault-linux-v1.5.8.zip
-        sha256: d94d76016f06c17df24289659ead2267f93e547228c240058740a32a72115071
+        url: https://polydez.com/download/keyvault-linux-v1.5.9.zip
+        sha256: a5d096b62530c12b33c717ecf462d5b92d2f7dbc59c5e4e7440e5ba3273e5add


### PR DESCRIPTION
Updating KeyVault to v1.5.9 with the following updates:

- Added support for 19 languages
- Import/export functionality now supported from iOS KeyVault (JSON support)